### PR TITLE
phpCAS::setDebug() is deprecated in favor of phpCAS::setLogger()

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -26,11 +26,11 @@ class CasManager {
 	public function __construct( array $config ) {
 		$this->parseConfig( $config );
 		if ( $this->config['cas_debug'] === true ) {
-			phpCAS::setDebug();
+			phpCAS::setLogger();
 			phpCAS::log( 'Loaded configuration:' . PHP_EOL
 			             . serialize( $config ) );
 		} else {
-			phpCAS::setDebug( $this->config['cas_debug'] );
+			phpCAS::setLogger( $this->config['cas_debug'] );
 		}
 
 		phpCAS::setVerbose( $this->config['cas_verbose_errors'] );


### PR DESCRIPTION
change introduced by 
apereo/phpcas (1.3.8 => 1.3.9)
